### PR TITLE
Add Show instances for the Rep types

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
     "purescript-foldable-traversable": "^3.0.0"
   },
   "devDependencies": {
-    "purescript-console": "^3.0.0"
+    "purescript-console": "^3.0.0",
+    "purescript-psci-support": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,17 @@
 {
   "private": true,
   "scripts": {
+    "install": "rimraf bower_components && bower install",
     "clean": "rimraf output && rimraf .pulp-cache",
     "build": "eslint src && pulp build -- --censor-lib --strict",
-    "test": "pulp test"
+    "test": "pulp test",
+    "pulp": "pulp"
   },
   "devDependencies": {
+    "bower": "^1.8.0",
     "eslint": "^3.17.1",
-    "pulp": "^10.0.4",
+    "pulp": "^11.0.0",
+    "purescript": "^0.11.5",
     "purescript-psa": "^0.5.0-rc.1",
     "rimraf": "^2.6.1"
   }

--- a/src/Data/Generic/Rep.purs
+++ b/src/Data/Generic/Rep.purs
@@ -12,7 +12,9 @@ module Data.Generic.Rep
   , Field(..)
   ) where
 
+import Prelude
 import Data.Maybe (Maybe(..))
+import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
 
 -- | A representation for types with no constructors.
 data NoConstructors
@@ -55,3 +57,24 @@ instance genericMaybe
   from Nothing = Inl (Constructor NoArguments)
   from (Just a) = Inr (Constructor (Argument a))
 
+instance showNoArguments :: Show NoArguments where
+  show _ = "NoArguments"
+
+instance showSum :: (Show a, Show b) => Show (Sum a b) where
+  show (Inl a) = "(Inl " <> show a <> ")"
+  show (Inr b) = "(Inr " <> show b <> ")"
+
+instance showProduct :: (Show a, Show b) => Show (Product a b) where
+  show (Product a b) = "(Product " <> show a <> " " <> show b <> ")"
+
+instance showConstructor :: (IsSymbol name, Show a) => Show (Constructor name a) where
+  show (Constructor a) = "(Constructor \"" <> reflectSymbol (SProxy :: SProxy name) <> "\" " <> show a <> ")"
+
+instance showArgument :: Show a => Show (Argument a) where
+  show (Argument a) = "(Argument " <> show a <> ")"
+
+instance showRec :: Show a => Show (Rec a) where
+  show (Rec a) = "(Rec " <> show a <> ")"
+
+instance showField :: (IsSymbol name, Show a) => Show (Field name a) where
+  show (Field a) = "(Field \"" <> reflectSymbol (SProxy :: SProxy name) <> "\" " <> show a <> ")"

--- a/src/Data/Generic/Rep.purs
+++ b/src/Data/Generic/Rep.purs
@@ -68,7 +68,7 @@ instance showProduct :: (Show a, Show b) => Show (Product a b) where
   show (Product a b) = "(Product " <> show a <> " " <> show b <> ")"
 
 instance showConstructor :: (IsSymbol name, Show a) => Show (Constructor name a) where
-  show (Constructor a) = "(Constructor \"" <> reflectSymbol (SProxy :: SProxy name) <> "\" " <> show a <> ")"
+  show (Constructor a) = "(Constructor " <> show (reflectSymbol (SProxy :: SProxy name)) <> " " <> show a <> ")"
 
 instance showArgument :: Show a => Show (Argument a) where
   show (Argument a) = "(Argument " <> show a <> ")"
@@ -77,4 +77,4 @@ instance showRec :: Show a => Show (Rec a) where
   show (Rec a) = "(Rec " <> show a <> ")"
 
 instance showField :: (IsSymbol name, Show a) => Show (Field name a) where
-  show (Field a) = "(Field \"" <> reflectSymbol (SProxy :: SProxy name) <> "\" " <> show a <> ")"
+  show (Field a) = "(Field " <> show (reflectSymbol (SProxy :: SProxy name)) <> " " <> show a <> ")"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -49,3 +49,5 @@ main = do
 
   logShow (bottom :: SimpleBounded)
   logShow (top :: SimpleBounded)
+
+  logShow (G.from $ cons 1 Nil)


### PR DESCRIPTION
I've been trying to learn and understand this library, and I found it useful to be able to `show` the generic rep types that are returned by `from`, to help visualise and understand the generic structure of a particular value.

For example, using the types in `Test.Main` in psci:

```
> from (Cons { head: 1, tail: Nil })
(Inr (Constructor "Cons" (Rec (Product (Field "head" 1) (Field "tail" Nil)))))

> from B
(Inr (Inl (Constructor "B" NoArguments)))
```

I had to add some missing dependencies and an install script to the `package.config` so I could build and run this project. I also added psci-support as a dev dependency to the bower.config, for being able to mess around with things in the interactive console. If you aren't cool with these changes, I've done them in separate commits so they can be reverted.