### PR TITLE
Added GenericShowFields instances for NoConstructors and NoArguments

### DIFF
--- a/src/Data/Generic/Rep.purs
+++ b/src/Data/Generic/Rep.purs
@@ -14,9 +14,7 @@ module Data.Generic.Rep
 
 import Prelude
 
---import Data.Eq (Eq(..))
 import Data.Maybe (Maybe(..))
---import Data.Show (Show(..))
 
 -- | A representation for types with no constructors.
 data NoConstructors

--- a/src/Data/Generic/Rep.purs
+++ b/src/Data/Generic/Rep.purs
@@ -12,25 +12,13 @@ module Data.Generic.Rep
   , Field(..)
   ) where
 
-import Prelude
-
 import Data.Maybe (Maybe(..))
 
 -- | A representation for types with no constructors.
 data NoConstructors
 
-derive instance eqNoConstructors :: Eq NoConstructors
-
-instance showNoConstructors :: Show NoConstructors where
-  show = const "{}"
-
 -- | A representation for constructors with no arguments.
 data NoArguments = NoArguments
-
-derive instance eqNoArguments :: Eq NoArguments
-
-instance showNoArguments :: Show NoArguments where
-  show = const "{}"
 
 -- | A representation for types with multiple constructors.
 data Sum a b = Inl a | Inr b

--- a/src/Data/Generic/Rep.purs
+++ b/src/Data/Generic/Rep.purs
@@ -12,13 +12,27 @@ module Data.Generic.Rep
   , Field(..)
   ) where
 
+import Prelude
+
+--import Data.Eq (Eq(..))
 import Data.Maybe (Maybe(..))
+--import Data.Show (Show(..))
 
 -- | A representation for types with no constructors.
 data NoConstructors
 
+derive instance eqNoConstructors :: Eq NoConstructors
+
+instance showNoConstructors :: Show NoConstructors where
+  show = const "{}"
+
 -- | A representation for constructors with no arguments.
 data NoArguments = NoArguments
+
+derive instance eqNoArguments :: Eq NoArguments
+
+instance showNoArguments :: Show NoArguments where
+  show = const "{}"
 
 -- | A representation for types with multiple constructors.
 data Sum a b = Inl a | Inr b

--- a/src/Data/Generic/Rep/Show.purs
+++ b/src/Data/Generic/Rep/Show.purs
@@ -66,10 +66,7 @@ instance genericShowFieldsField
     [reflectSymbol (SProxy :: SProxy name) <> ": " <> show a]
 
 instance genericShowFieldsNoArguments :: GenericShowFields NoArguments where
-  genericShowFields _ = ["{}"]
-
-instance genericShowFieldsNoConstructors :: GenericShowFields NoConstructors where
-  genericShowFields _ = ["{}"]
+  genericShowFields _ = []
 
 -- | A `Generic` implementation of the `show` member from the `Show` type class.
 genericShow :: forall a rep. Generic a rep => GenericShow rep => a -> String

--- a/src/Data/Generic/Rep/Show.purs
+++ b/src/Data/Generic/Rep/Show.purs
@@ -8,7 +8,7 @@ module Data.Generic.Rep.Show
   , genericShowFields
   ) where
 
-import Prelude (class Show, show, (<>))
+import Prelude (class Show, show, (<>), const)
 import Data.Foldable (intercalate)
 import Data.Generic.Rep
 import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
@@ -64,6 +64,12 @@ instance genericShowFieldsField
     => GenericShowFields (Field name a) where
   genericShowFields (Field a) =
     [reflectSymbol (SProxy :: SProxy name) <> ": " <> show a]
+
+instance genericShowFieldsNoArguments :: GenericShowFields NoArguments where
+  genericShowFields _ = ["{}"]
+
+instance genericShowFieldsNoConstructors :: GenericShowFields NoConstructors where
+  genericShowFields _ = ["{}"]
 
 -- | A `Generic` implementation of the `show` member from the `Show` type class.
 genericShow :: forall a rep. Generic a rep => GenericShow rep => a -> String

--- a/src/Data/Generic/Rep/Show.purs
+++ b/src/Data/Generic/Rep/Show.purs
@@ -8,7 +8,7 @@ module Data.Generic.Rep.Show
   , genericShowFields
   ) where
 
-import Prelude (class Show, show, (<>), const)
+import Prelude (class Show, show, (<>))
 import Data.Foldable (intercalate)
 import Data.Generic.Rep
 import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)


### PR DESCRIPTION
We needed these in order to support

```haskell
derive instance genericA :: G.Generic A _

instance showGenericA :: Show A where
  show = G.genericShow
```

I'm not sure `["{}"]` is the right thing to return here though, so I'm open to suggestions.