### PR TITLE
add Generic Either instance

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,7 @@
     "purescript-enums": "^4.0.0",
     "purescript-foldable-traversable": "^4.0.0",
     "purescript-maybe": "^4.0.0",
+    "purescript-either": "^4.0.0",
     "purescript-newtype": "^3.0.0",
     "purescript-prelude": "^4.0.0"
   },

--- a/src/Data/Generic/Rep.purs
+++ b/src/Data/Generic/Rep.purs
@@ -11,6 +11,7 @@ module Data.Generic.Rep
   ) where
 
 import Data.Maybe (Maybe(..))
+import Data.Either (Either(..))
 
 -- | A representation for types with no constructors.
 data NoConstructors
@@ -46,3 +47,11 @@ instance genericMaybe
   from Nothing = Inl (Constructor NoArguments)
   from (Just a) = Inr (Constructor (Argument a))
 
+instance genericEither
+  :: Generic (Either a b) (Sum (Constructor "Left" (Argument a))
+                               (Constructor "Right" (Argument b))) where
+  to (Inl (Constructor (Argument a))) = Left a
+  to (Inr (Constructor (Argument b))) = Right b
+
+  from (Left a) = Inl (Constructor (Argument a))
+  from (Right b) = Inr (Constructor (Argument b))


### PR DESCRIPTION
I am trying to encode/decode data to JSON and I have some types with Either, I need a `Generic` instance to use Foreign.Generic to do this.